### PR TITLE
HCLOUD-2963_Add-semantic-relese-to-the-wave-nodes-catalog-blueprint_Darius-Weiberg

### DIFF
--- a/.github/workflows/upload-to-s3.yaml
+++ b/.github/workflows/upload-to-s3.yaml
@@ -45,6 +45,13 @@ jobs:
           if [ -z $version ]; then version="0.0.0"; fi
           echo "version=$version" >> $GITHUB_OUTPUT
 
+      - name: Check changelog and convert to correct format
+        run: |
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          node scripts/check-changelog.js $TAG_NAME
+          node scripts/convert-changelog.js
+
+      # ToDo: Pass the changelog-converted.json (created in step above) to this action
       - name: Upload catalog and update registry
         id: upload
         uses: moovit-sp-gmbh/hcloud-catalog-upload-action@main

--- a/changelog-howTo.md
+++ b/changelog-howTo.md
@@ -1,10 +1,10 @@
-Before releasing a new version of your catalog by pushing a tag to the repository, the changelog.json file must 
-be updated to include the changes accompanying the new release. There are specific rules for writing the changelog 
-to ensure it can be parsed and displayed in Stream Designer Studio and remains consistent with the changelogs 
+Before releasing a new version of your catalog by pushing a tag to the repository, the changelog.json file must
+be updated to include the changes accompanying the new release. There are specific rules for writing the changelog
+to ensure it can be parsed and displayed in Stream Designer Studio and remains consistent with the changelogs
 of other catalogs. Below, you can find an example of a correctly formatted changelog.
 
-We adhere to the Conventional Commits Specification (https://www.conventionalcommits.org), which defines how to 
-determine the new version based on the type of code changes made. When writing the changelog, you must categorize 
+We adhere to the [Conventional Commits Specification](https://www.conventionalcommits.org), which defines how to
+determine the new version based on the type of code changes made. When writing the changelog, you must categorize
 your changes into predefined types (be sure to use the exact names listed here):
 
 - Bug Fixes (correspond to PATCH in Semantic Versioning)
@@ -16,13 +16,14 @@ your changes into predefined types (be sure to use the exact names listed here):
 The only types of interest to the end user of your catalog are bug fixes and new features. Other types of changes
 are only relevant if they are breaking and thus should not appear in the changelog by default.
 
-In addition to listing your changes, you also need to specify the date of the release and the new version number. 
-Determining the version number works as follows: If you have one or more breaking changes, increase the first digit 
-(major) and reset the other two digits to zero, regardless of whether you have bug fixes or features. If you introduce 
-new features without breaking changes, increment the second digit (minor) and set the third digit (patch) to zero. If 
+In addition to listing your changes, you also need to specify the date of the release and the new version number.
+Determining the version number works as follows: If you have one or more breaking changes, increase the first digit
+(major) and reset the other two digits to zero, regardless of whether you have bug fixes or features. If you introduce
+new features without breaking changes, increment the second digit (minor) and set the third digit (patch) to zero. If
 there are no breaking changes and no new features, but there are bug fixes, only increment the minor version.
 
 Additional notes:
+
 - New releases must always be included at the top of the changelog
 - Order of changes inside the releases doesn't matter
 - Do not remove older releases
@@ -30,6 +31,7 @@ Additional notes:
 
 Here is an example of how a correctly formatted changelog can look like after the third release:
 
+```json
 [
   {
     "version": "2.1.0",
@@ -80,3 +82,4 @@ Here is an example of how a correctly formatted changelog can look like after th
     ]
   }
 ]
+```

--- a/changelog-howTo.txt
+++ b/changelog-howTo.txt
@@ -1,0 +1,82 @@
+Before releasing a new version of your catalog by pushing a tag to the repository, the changelog.json file must 
+be updated to include the changes accompanying the new release. There are specific rules for writing the changelog 
+to ensure it can be parsed and displayed in Stream Designer Studio and remains consistent with the changelogs 
+of other catalogs. Below, you can find an example of a correctly formatted changelog.
+
+We adhere to the Conventional Commits Specification (https://www.conventionalcommits.org), which defines how to 
+determine the new version based on the type of code changes made. When writing the changelog, you must categorize 
+your changes into predefined types (be sure to use the exact names listed here):
+
+- Bug Fixes (correspond to PATCH in Semantic Versioning)
+- Features (correspond to MINOR in Semantic Versioning)
+- Code Refactoring (do not lead to a new release by default)
+- Performance Improvements (do not lead to a new release by default)
+- Miscellaneous Chores (do not lead to a new release by default)
+
+The only types of interest to the end user of your catalog are bug fixes and new features. Other types of changes
+are only relevant if they are breaking and thus should not appear in the changelog by default.
+
+In addition to listing your changes, you also need to specify the date of the release and the new version number. 
+Determining the version number works as follows: If you have one or more breaking changes, increase the first digit 
+(major) and reset the other two digits to zero, regardless of whether you have bug fixes or features. If you introduce 
+new features without breaking changes, increment the second digit (minor) and set the third digit (patch) to zero. If 
+there are no breaking changes and no new features, but there are bug fixes, only increment the minor version.
+
+Additional notes:
+- New releases must always be included at the top of the changelog
+- Order of changes inside the releases doesn't matter
+- Do not remove older releases
+- The first release must be version 1.0.0
+
+Here is an example of how a correctly formatted changelog can look like after the third release:
+
+[
+  {
+    "version": "2.1.0",
+    "date": "2024-09-28",
+    "changes": [
+      {
+        "description": "Short description (one sentence) of your change in present tense",
+        "type": "Features",
+        "breaking": false
+      },
+      {
+        "description": "Short description (one sentence) of your change in present tense",
+        "type": "Bug Fixes",
+        "breaking": false
+      }
+    ]
+  },
+  {
+    "version": "2.0.0",
+    "date": "2024-09-17",
+    "changes": [
+      {
+        "description": "Short description (one sentence) of your change in present tense",
+        "type": "Features",
+        "breaking": false
+      },
+      {
+        "description": "Short description (one sentence) of your change in present tense",
+        "type": "Bug Fixes",
+        "breaking": true
+      },
+      {
+        "description": "Short description (one sentence) of your change in present tense",
+        "type": "Code Refactoring",
+        "breaking": true
+      }
+    ]
+  },
+  {
+    "version": "1.0.0",
+    "date": "2024-09-04",
+    "changes": [
+      {
+        "description": "Initial release",
+        "type": "Features",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/changelog.json
+++ b/changelog.json
@@ -1,0 +1,13 @@
+[
+  {
+    "version": "1.0.0",
+    "date": "2024-09-04",
+    "changes": [
+      {
+        "description": "For your first release, just update the date above and rename this line to 'Initial release'",
+        "type": "Features",
+        "breaking": false
+      }
+    ]
+  }
+]

--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -1,0 +1,60 @@
+const fs = require('fs');
+
+let tag = process.argv[2];
+tag = tag.startsWith('v') ? tag.slice(1) : tag;
+
+let changelog;
+
+try {
+    const data = fs.readFileSync('changelog.json', 'utf8');
+    changelog = JSON.parse(data);
+} catch (err) {
+    console.error('Error reading changelog.json:', err.message);
+    process.exit(1);
+}
+
+if (!Array.isArray(changelog) || changelog.length === 0) {
+    console.error('Invalid changelog.json format.');
+    process.exit(1);
+}
+
+const firstEntry = changelog[0];
+
+const semverRegex = /^(\d+)\.(\d+)\.(\d+)$/;
+if (!semverRegex.test(firstEntry.version)) {
+    console.error(`Version ${firstEntry.version} in changelog.json is not a valid version number. Must be 'X.X.X'`);
+    process.exit(1);
+}
+
+if (firstEntry.version !== tag) {
+    console.error("Changelog version and pushed tag don't match. You probably forgot to update the changelog");
+    process.exit(1);
+}
+
+const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+if (!dateRegex.test(firstEntry.date)) {
+    console.error(`Date ${firstEntry.date} is not in YYYY-MM-DD format.`);
+    process.exit(1);
+}
+
+const validTypes = [
+    'Bug Fixes',
+    'Features',
+    'Code Refactoring',
+    'Performance Improvements',
+    'Miscellaneous Chores'
+];
+
+if (!Array.isArray(firstEntry.changes) || firstEntry.changes.length === 0) {
+    console.error('No changes found in the first entry of changelog.json.');
+    process.exit(1);
+}
+
+for (const change of firstEntry.changes) {
+    if (!validTypes.includes(change.type)) {
+        console.error(`Invalid change type: ${change.type}`);
+        process.exit(1);
+    }
+}
+
+console.log('Changelog validation passed.');

--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -31,9 +31,8 @@ if (firstEntry.version !== tag) {
     process.exit(1);
 }
 
-const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
-if (!dateRegex.test(firstEntry.date)) {
-    console.error(`Date ${firstEntry.date} is not in YYYY-MM-DD format.`);
+if (isNaN(Date.parse(firstEntry.date))) {
+    console.error(`Date ${firstEntry.date} is not in a valid format.`);
     process.exit(1);
 }
 

--- a/scripts/convert-changelog.mjs
+++ b/scripts/convert-changelog.mjs
@@ -1,0 +1,50 @@
+const fs = require('fs');
+
+const changelog = JSON.parse(fs.readFileSync('changelog.json', 'utf8'));
+
+const convertedChangelog = changelog.map((release) => {
+  const convertedRelease = {
+    version: release.version,
+    date: release.date,
+    commitGroups: []
+  };
+
+  const commitGroupsMap = {};
+
+  const breakingChanges = [];
+
+  release.changes.forEach((change) => {
+    const commit = { message: change.description };
+
+    if (change.breaking) {
+      breakingChanges.push(commit);
+    }
+
+    if (!commitGroupsMap[change.type]) {
+      commitGroupsMap[change.type] = [];
+    }
+    commitGroupsMap[change.type].push(commit);
+  });
+
+  // If there are breaking changes, add the BREAKING CHANGES group first
+  if (breakingChanges.length > 0) {
+    convertedRelease.commitGroups.push({
+      title: 'BREAKING CHANGES',
+      commits: breakingChanges
+    });
+  }
+
+  // Add the other commit groups
+  for (const [type, commits] of Object.entries(commitGroupsMap)) {
+    convertedRelease.commitGroups.push({
+      title: type,
+      commits: commits
+    });
+  }
+
+  return convertedRelease;
+});
+
+fs.writeFileSync('changelog-converted.json', JSON.stringify(convertedChangelog, null, 2));
+
+console.log('Changelog has been converted and saved to changelog-converted.json');


### PR DESCRIPTION
Add everything necessary to create changelogs for releases