### PR TITLE
HCLOUD-3069_Add-support-for-dev-releases_Darius-Weiberg

### DIFF
--- a/.github/workflows/upload-to-s3.yaml
+++ b/.github/workflows/upload-to-s3.yaml
@@ -34,12 +34,6 @@ jobs:
           echo "logoUrl=$(node -e 'console.log(require("./bundle.js").default.logoUrl)')" >> "$GITHUB_OUTPUT"
           echo "minimumEngineVersion=$(node -e 'console.log(require("./bundle.js").default.minimumEngineVersion)')" >> "$GITHUB_OUTPUT"
 
-      - name: Setup upload folder
-        run: |
-          mkdir -p upload/docs
-          cp ./bundle.js ./specification.json upload/
-          find ${{ github.workspace }}/lib/nodes -type f -name '*.md' -exec cp {} ${{ github.workspace }}/upload/docs/ \;
-
       - name: Extract version from tag and remove "v" prefix
         id: catalog-version
         run: |
@@ -57,7 +51,13 @@ jobs:
           node scripts/check-changelog.mjs ${{ steps.catalog-version.outputs.version }}
           node scripts/convert-changelog.mjs
 
-      # ToDo: Pass the changelog-converted.json (created in step above) to this action
+      - name: Setup upload folder
+        run: |
+          mkdir -p upload/docs
+          cp ./bundle.js ./specification.json upload/
+          cp ./changelog-converted.json upload/changelog.json
+          find ${{ github.workspace }}/lib/nodes -type f -name '*.md' -exec cp {} ${{ github.workspace }}/upload/docs/ \;
+
       - name: Upload catalog and update registry
         id: upload
         uses: moovit-sp-gmbh/hcloud-catalog-upload-action@main
@@ -75,9 +75,6 @@ jobs:
           version: ${{ steps.catalog-version.outputs.version }}
           source_dir: ${{ github.workspace }}/upload
           dest_dir: "<your path>"
-          changelog: |
-            Nothing changed
-          dev: false
           on_fail: delete
 
       - name: Print catalog registry URL

--- a/.github/workflows/upload-to-s3.yaml
+++ b/.github/workflows/upload-to-s3.yaml
@@ -40,18 +40,21 @@ jobs:
           cp ./bundle.js ./specification.json upload/
           find ${{ github.workspace }}/lib/nodes -type f -name '*.md' -exec cp {} ${{ github.workspace }}/upload/docs/ \;
 
-      - name: Extract version from tag
+      - name: Extract version from tag and remove "v" prefix
         id: catalog-version
         run: |
           tag=${{ github.ref_name }}
+          if [[ $tag != v* ]]; then
+            echo "Tag does not start with 'v'. Failing the workflow."
+            exit 1
+          fi
           version=${tag:1}
           if [ -z $version ]; then version="0.0.0"; fi
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Check changelog and convert to correct format
         run: |
-          TAG_NAME=${GITHUB_REF#refs/tags/}
-          node scripts/check-changelog.mjs $TAG_NAME
+          node scripts/check-changelog.mjs ${{ steps.catalog-version.outputs.version }}
           node scripts/convert-changelog.mjs
 
       # ToDo: Pass the changelog-converted.json (created in step above) to this action

--- a/.github/workflows/upload-to-s3.yaml
+++ b/.github/workflows/upload-to-s3.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload catalog and update registry
         id: upload
-        uses: moovit-sp-gmbh/hcloud-catalog-upload-action@main
+        uses: moovit-sp-gmbh/hcloud-catalog-upload-action@v1.0.0
         with:
           endpoint: <S3 endpoint>
           bucket: <name of your S3 bucket>

--- a/changelog-howTo.md
+++ b/changelog-howTo.md
@@ -22,6 +22,8 @@ Determining the version number works as follows: If you have one or more breakin
 new features without breaking changes, increment the second digit (minor) and set the third digit (patch) to zero. If
 there are no breaking changes and no new features, but there are bug fixes, only increment the minor version.
 
+While providing a changelog entry for a main release is mandatory, changelog entries for dev releases (e.g. v1.2.3-dev-1) are optional. In the Stream Designer Studio, a toggle switch button allows the user to display dev release changelogs.
+
 Additional notes:
 
 - New releases must always be included at the top of the changelog

--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -1,8 +1,6 @@
 import fs from "fs";
 
 let tag = process.argv[2];
-tag = tag.startsWith("v") ? tag.slice(1) : tag;
-
 let changelog;
 
 try {
@@ -20,19 +18,24 @@ if (!Array.isArray(changelog) || changelog.length === 0) {
 
 const firstEntry = changelog[0];
 
-const semverRegex = /^(\d+)\.(\d+)\.(\d+)$/;
+const semverRegex = /^(\d+)\.(\d+)\.(\d+)(-dev-\d+)?$/;
 if (!semverRegex.test(firstEntry.version)) {
     console.error(
-        `Version ${firstEntry.version} in changelog.json is not a valid version number. Must be 'X.X.X'`
+        `Version ${firstEntry.version} in changelog.json is not a valid version number. Must be 'X.X.X' or 'X.X.X-dev-X`
     );
     process.exit(1);
 }
 
 if (firstEntry.version !== tag) {
-    console.error(
-        "Changelog version and pushed tag don't match. You probably forgot to update the changelog"
-    );
-    process.exit(1);
+    if (tag.includes("dev")) {
+        // Changelog for dev release is optional, so successfully end script if not provided
+        process.exit(0); 
+    } else {
+        console.error(
+            `Changelog version '${firstEntry.version}' and pushed tag '${tag}' don't match. You probably forgot to update the changelog`
+        );
+        process.exit(1);
+    }
 }
 
 if (isNaN(Date.parse(firstEntry.date))) {

--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -16,30 +16,30 @@ if (!Array.isArray(changelog) || changelog.length === 0) {
     process.exit(1);
 }
 
-const firstEntry = changelog[0];
+const latestEntry = changelog[0];
 
 const semverRegex = /^(\d+)\.(\d+)\.(\d+)(-dev-\d+)?$/;
-if (!semverRegex.test(firstEntry.version)) {
+if (!semverRegex.test(latestEntry.version)) {
     console.error(
-        `Version ${firstEntry.version} in changelog.json is not a valid version number. Must be 'X.X.X' or 'X.X.X-dev-X`
+        `Version ${latestEntry.version} in changelog.json is not a valid version number. Must be 'X.X.X' or 'X.X.X-dev-X`
     );
     process.exit(1);
 }
 
-if (firstEntry.version !== tag) {
+if (latestEntry.version !== tag) {
     if (tag.includes("dev")) {
         // Changelog for dev release is optional, so successfully end script if not provided
         process.exit(0); 
     } else {
         console.error(
-            `Changelog version '${firstEntry.version}' and pushed tag '${tag}' don't match. You probably forgot to update the changelog`
+            `Changelog version '${latestEntry.version}' and pushed tag '${tag}' don't match. You probably forgot to update the changelog`
         );
         process.exit(1);
     }
 }
 
-if (isNaN(Date.parse(firstEntry.date))) {
-    console.error(`Date ${firstEntry.date} is not in a valid format.`);
+if (isNaN(Date.parse(latestEntry.date))) {
+    console.error(`Date ${latestEntry.date} is not in a valid format.`);
     process.exit(1);
 }
 
@@ -51,12 +51,12 @@ const validTypes = [
     "Miscellaneous Chores",
 ];
 
-if (!Array.isArray(firstEntry.changes) || firstEntry.changes.length === 0) {
-    console.error("No changes found in the first entry of changelog.json.");
+if (!Array.isArray(latestEntry.changes) || latestEntry.changes.length === 0) {
+    console.error("No changes found in the latest entry of changelog.json.");
     process.exit(1);
 }
 
-for (const change of firstEntry.changes) {
+for (const change of latestEntry.changes) {
     if (!validTypes.includes(change.type)) {
         console.error(`Invalid change type: ${change.type}`);
         process.exit(1);


### PR DESCRIPTION
I also did changes in the catalog-upload-action in order to make this work, they are not tested yet: https://github.com/moovit-sp-gmbh/hcloud-catalog-upload-action/pull/4